### PR TITLE
Improved upload/replace performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,9 @@ $ 🍋  lemonsync
 
 | Option | Description |
 | ------ | ----------- |
-| `--version` | Show the current tool version                 |
+| `--reset=local` | Overwrite local theme with store version |
+| `--reset=remote` | Overwrite store theme with local version |
+| `--version` | Show the current version of `lemonsync` |
+| `--verbose` | Show additional logging detail |
+| `--network-logging` | Show detail of each network request |
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ $ 🍋  lemonsync
 | Option | Description |
 | ------ | ----------- |
 | `--reset=local` | Overwrite local theme with store version |
-| `--reset=remote` | Overwrite store theme with local version |
 | `--version` | Show the current version of `lemonsync` |
 | `--verbose` | Show additional logging detail |
 | `--network-logging` | Show detail of each network request |
+| `--reset=remote` | Overwrite store theme with local version **Warning: this option will overwrite your store's remote theme and can delete your remote theme if used incorrectly.** |
+
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ _Note: You may need to start your terminal application after uninstalling previo
 
 ## Usage
 
-1. Download a theme from your [LemonStand](https://lemonstand.com/) store. 
+1. Download a theme from your [LemonStand](https://lemonstand.com/) store.
 
 2. Create a JSON file, **lemonsync.json** and place it in your theme folder. This JSON should contain the following data:
 
@@ -54,4 +54,11 @@ _Note: You may need to start your terminal application after uninstalling previo
 ```
 $ 🍋  lemonsync
 ```
+
+
+## Additional options
+
+| Option | Description |
+| ====== | =========== |
+| --version  | Show the current tool version                 |
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ $ 🍋  lemonsync
 ## Additional options
 
 | Option | Description |
-| ====== | =========== |
-| --version  | Show the current tool version                 |
+| ------ | ----------- |
+| `--version` | Show the current tool version                 |
 

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -13,6 +13,7 @@ var AWS      = require('aws-sdk'),
 var defaults = {
     scanTimeout: 30,
     s3Timeout: 300000, /* 5 minutes */
+    maximumFileCount: 10000,
     version: '1.0.11'
 };
 
@@ -495,7 +496,7 @@ function getIdentity(apiKey, cb) {
             }
             if (response) {
                 if (response.statusCode == 401) {
-                    console.log("The API Access Token isn't valid for "+apiHost+". Please check that your Access Token is correct and not expired.");
+                    console.log("The API Access Token isn't valid for " + apiHost + ". Please check that your Access Token is correct and not expired.");
                 } else if (response.statusCode != 200) {
                     console.log("Could not connect to the LemonStand store.");
                 }
@@ -531,7 +532,7 @@ function getS3ListOfObjects(identityData) {
     var listObjectsV2Params = {
         Bucket: identityData.bucket,
         Prefix: prefix + theme + '/',
-        MaxKeys: 10000
+        MaxKeys: defaults.maximumFileCount
     };
 
     s3.listObjectsV2(listObjectsV2Params, function(err, objects) {

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -17,8 +17,6 @@ var defaults = {
     version: '1.0.11'
 };
 
-// defaults.s3Timeout = 50000; // < 1 minute (debugging)
-
 /**
  * S3 security variables
  */
@@ -266,9 +264,9 @@ function uploadLocalToStore(changedFiles) {
     var count = 1;
 
     /** S3 file completion helper */
-    var onFilePut = function(err, data) {
+    var onFileUpdate = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, this.headers);
+            console.details('remote', 'Update failed', err, data);
         } else {
             console.details('remote', 'Update OK for', data.headers);
         }
@@ -303,7 +301,7 @@ function uploadLocalToStore(changedFiles) {
             Body: changedFiles[key]
         };
 
-        var themeFileUpdater = s3.putObject(params, onFilePut)
+        var themeFileUpdater = s3.upload(params, onFileUpdate)
                                     .promise();
 
         uploadList.push(themeFileUpdater);

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -268,7 +268,7 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFilePut = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, this.headers, data.headers);
+            console.details('remote', 'Update failed', err, this.headers);
         } else {
             console.details('remote', 'Update OK for', data.headers);
         }

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -308,7 +308,7 @@ function uploadLocalToStore(changedFiles) {
         count++;
     }
 
-    console.details('remote', 'Updating', uploadList.length, '/', totalChanges, 'files');
+    console.details('remote', 'Updating', uploadList.length, '/', totalChanges, 'files ...');
 
     // Upload files in a batch + tickle cache and continue watching
 

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -17,7 +17,7 @@ var defaults = {
     version: '1.0.11'
 };
 
-defaults.s3Timeout = 50000; // < 1 minute
+// defaults.s3Timeout = 50000; // < 1 minute (debugging)
 
 /**
  * S3 security variables
@@ -268,7 +268,7 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFilePut = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, err.headers);
+            console.details('remote', 'Update failed', err, this.headers, data.headers);
         } else {
             console.details('remote', 'Update OK for', data.headers);
         }

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -17,6 +17,8 @@ var defaults = {
     version: '1.0.11'
 };
 
+defaults.s3Timeout = 50000; // < 1 minute
+
 /**
  * S3 security variables
  */
@@ -266,7 +268,9 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFilePut = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, err.httpResponse, this.err.httpResponse);
+            var r1 = err.httpResponse;
+            var r2 = this.error.httpResponse;
+            console.details('remote', 'Update failed', err, r1, r2);
         } else {
             console.details('remote', 'Update OK for', data.headers);
         }

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -537,7 +537,11 @@ function processGlobalCommandLine() {
 
     if (process.argv.includes('--verbose')) {
         verbose = true;
-        request.debug = true;
         console.log('Detailed logging is ON');
+    }
+
+    if (process.argv.includes('--network-logging')) {
+        request.debug = true;
+        console.log('Network logging is ON');
     }
 }

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -268,9 +268,7 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFilePut = function(err, data) {
         if (err) {
-            var r1 = err.httpResponse;
-            var r2 = this.error.httpResponse;
-            console.details('remote', 'Update failed', err, r1, r2);
+            console.details('remote', 'Update failed', err, err.headers);
         } else {
             console.details('remote', 'Update OK for', data.headers);
         }

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -278,12 +278,14 @@ function uploadLocalToStore(changedFiles) {
 
     for (var key in changedFiles) {
         var cacheKey = key.replace(prefix + theme + '/', '');
-        var size = changedFiles[key].length / 1024 / 1024;
-
-        fileSizeMB = size.toFixed(2);
+        var fileSizeMB = changedFiles[key].length / 1024 / 1024;
 
         console.log('- ' + cacheKey.replace(prefix, ''));
-        console.details('remote', 'Preparing changes for', cacheKey, '(', count, '/', totalChanges, ')', fileSizeMB, 'MB');
+
+        console.details('remote', 'Preparing changes for',
+            cacheKey,
+            '(', count, '/', totalChanges, ')',
+            fileSizeMB.toFixed(2), 'MB');
 
         if (!changedFiles.hasOwnProperty(key)) {
             continue; // skip non-file object props

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -12,6 +12,7 @@ var AWS      = require('aws-sdk'),
 /** Some CLI defaults */
 var defaults = {
     scanTimeout: 30,
+    s3Timeout: 300000, /* 5 minutes */
     version: '1.0.11'
 };
 
@@ -264,9 +265,9 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFilePut = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, err.httpResponse, this.err.httpResponse);
+            console.details('remote', 'Update failed', err, data.headers, err.httpResponse, this.err.httpResponse);
         } else {
-            console.details('remote', 'Update OK');
+            console.details('remote', 'Update OK for', data.headers);
         }
     }
 
@@ -521,7 +522,7 @@ function getS3ListOfObjects(identityData) {
         sessionToken: identityData.token,
         region: 'us-east-1',
         httpOptions: {
-            timeout: 300000 /* increase timeout for larger files */
+            timeout: defaults.s3Timeout
         }
     });
 

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -266,9 +266,9 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFileUpdate = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, data);
+            console.details('remote', 'Update failed', err);
         } else {
-            console.details('remote', 'Update OK for', data.headers);
+            console.details('remote', 'Update OK for', data.Location);
         }
     }
 

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -266,7 +266,7 @@ function uploadLocalToStore(changedFiles) {
     /** S3 file completion helper */
     var onFilePut = function(err, data) {
         if (err) {
-            console.details('remote', 'Update failed', err, data.headers, err.httpResponse, this.err.httpResponse);
+            console.details('remote', 'Update failed', err, err.httpResponse, this.err.httpResponse);
         } else {
             console.details('remote', 'Update OK for', data.headers);
         }

--- a/notes.md
+++ b/notes.md
@@ -1,2 +1,4 @@
 
 - Better S3 uploads: https://stackoverflow.com/questions/42394429/aws-sdk-s3-best-way-to-recursively-list-all-keys-with-listobjectsv2
+- fs.watch may fail in certain cases (https://github.com/paulmillr/chokidar)
+- add timing with console.time

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,2 @@
+
+- Better S3 uploads: https://stackoverflow.com/questions/42394429/aws-sdk-s3-best-way-to-recursively-list-all-keys-with-listobjectsv2

--- a/package.json
+++ b/package.json
@@ -11,15 +11,14 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tomcornall/lemonsync-js.git"
+    "url": "git+https://github.com/lemonstand/lemonsync-js.git"
   },
   "bugs": {
-    "url": "https://github.com/tomcornall/lemonsync-js/issues"
+    "url": "https://github.com/lemonstand/lemonsync-js/issues"
   },
-  "homepage": "https://github.com/tomcornall/lemonsync-js#readme",
+  "homepage": "https://github.com/lemonstand/lemonsync-js#readme",
   "dependencies": {
     "aws-sdk": "^2.117.0",
-    "commander": "^2.11.0",
     "fs": "0.0.1-security",
     "ignore": "^3.3.5",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
- Switches to `upload` versus `put`, allowing requests to be multipart/parallel (Fixes #5)
- Adds command line options for trace (focused on upload/replace path)
- Adds command line options for version (Fixes #6)
- Adds more error reporting
