### PR TITLE
Update readme JSON file link to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ _Note: You may need to start your terminal application after uninstalling previo
 ```
 {
   "theme_code": "zest",
-  "store": "http://yourstore.lemonstand.com",
+  "store": "https://yourstore.lemonstand.com",
   "api_token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345678910",
   "ignore_patterns": [ "*.tmp", ".git", "lemonsync.json" ]
 }


### PR DESCRIPTION
Got a report from a developer saying they had used the lemonsync.json file we provide as a template but it had a http://yourstore.lemonstand.com link in it for "store", and it wasn't clear they should be connecting over https until they got a connection error. Changed the link to use https...