### PR TITLE
Switched to node-watch instead of default fs.watch

### DIFF
--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -414,7 +414,6 @@ function watchForChanges() {
     console.log('\r\n🍋  Watching for changes... 🍋\r\n');
 
     watch(watchDir, {recursive: true}, function(eventType, filename) {
-	console.log(eventType);
         watchTriggered(eventType, filename);
     });
 }

--- a/bin/lemonsync.js
+++ b/bin/lemonsync.js
@@ -8,7 +8,8 @@ var AWS      = require('aws-sdk'),
     pathModule = require('path'),
     ignore = require("ignore"),
     rimraf = require("rimraf"),
-    mime = require('mime');
+    mime = require('mime'),
+    watch = require('node-watch');
 
 /** Some CLI defaults */
 var defaults = {
@@ -412,7 +413,8 @@ function uploadLocalToStore(changedFiles) {
 function watchForChanges() {
     console.log('\r\n🍋  Watching for changes... 🍋\r\n');
 
-    fs.watch(watchDir, {recursive: true}, function(eventType, filename) {
+    watch(watchDir, {recursive: true}, function(eventType, filename) {
+	console.log(eventType);
         watchTriggered(eventType, filename);
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemonsync",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Tool for Lemon-sync'ing",
   "main": "lemonsync.js",
   "scripts": {
@@ -24,6 +24,7 @@
     "mime": "^2.0.3",
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.1",
+    "node-watch": "^0.5.5",
     "path": "^0.12.7",
     "readline": "^1.3.0",
     "request": "^2.81.0",


### PR DESCRIPTION
According to the node documentation, recursive filesystem watching is only available on Windows and macO, meaning Lemonsync is completely unusable for Linux platforms.

See the caveats listed in the NodeJS documentation here:
https://nodejs.org/api/fs.html#fs_caveats

With these changes, Lemonsync is working properly on Ubuntu 16.